### PR TITLE
fix paths

### DIFF
--- a/bootstrap/overlays/default/kustomization.yaml
+++ b/bootstrap/overlays/default/kustomization.yaml
@@ -1,10 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: openshift-gitops
-
 bases:
-# Install RH GitOps
+# Install OpenShift GitOps
 - ../../base
-# Install and configure components via RH GitOps even RH GitOps
-- ../../../argoconfig
+# Install and configure components via OpenShift GitOps
+- ../../../argo-config


### PR DESCRIPTION
problem in base kustomization with namespace specification (not needed) and path of argo-config.